### PR TITLE
Update docker tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The HDP models enable mapping of methylated bases to your reference sequence.
 Given the installation is often long, tedious and somewhat fragile. So, we recommend using Docker to run signalAlign.
 
 #### Docker image
+`ucscbailey/signalalign:latest`
+
+We do not store any test data within the docker image so, in order to test the docker image, clone the repo and run the following command from within
+the signalAlign home directory. 
 
 `docker run -it -v "$(pwd)":/data ucscbailey/signalalign:latest run --config tests/docker_runSignalAlign-config.json`
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The HDP models enable mapping of methylated bases to your reference sequence.
 
 ## Installation:
 
-Given the installation is often long, tedious and somewhat fragile we recommend using Docker to run signalAlign.
+Given the installation is often long, tedious and somewhat fragile. So, we recommend using Docker to run signalAlign.
 
 #### Docker image
 
-ucscbailey/signalalign:latest
+`docker run -it -v "$(pwd)":/data ucscbailey/signalalign:latest run --config tests/docker_runSignalAlign-config.json`
 
 ### Installation:
 
@@ -74,7 +74,7 @@ python3.7 -m pytest
 5. Generate positions file (see [Positions File Specification](#positions-file-specification))
 6. Create a config file. An example config file is located in [tests](tests/runSignalAlign-config.json).
 ```
-runSignalAlign.py run --config tests/runSignalAlign-config.json &> log_file.txt
+runSignalAlign.py run --config tests/runSignalAlign-config.json
 ```
 7. Run signalAlign 
 

--- a/tests/docker_runSignalAlign-config.json
+++ b/tests/docker_runSignalAlign-config.json
@@ -1,0 +1,43 @@
+{
+  "signal_alignment_args": {
+    "target_regions": null,
+    "track_memory_usage": false,
+    "threshold": 0.01,
+    "event_table": false,
+    "embed": false,
+    "delete_tmp": false,
+    "output_format": "full"
+  },
+  "samples": [
+    {
+      "positions_file": null,
+      "fast5_dirs": ["./tests/minion_test_reads/one_R9_canonical_ecoli"],
+      "bwa_reference": "./tests/test_sequences/E.coli_K12.fasta",
+      "fofns": [],
+      "readdb": "./tests/minion_test_reads/canonical_ecoli_R9/canonical_ecoli.readdb",
+      "fw_reference": null,
+      "bw_reference": null,
+      "kmers_from_reference": false,
+      "motifs": null,
+      "name": "canonical",
+      "probability_threshold": 0.8,
+      "number_of_kmer_assignments": 10,
+      "alignment_file": "./tests/minion_test_reads/canonical_ecoli_R9/canonical_ecoli.bam",
+      "recursive": false,
+      "assignments_dir": null
+    }
+  ],
+  "path_to_bin": "/bin",
+  "complement_hdp_model": null,
+  "template_hdp_model": null,
+  "complement_hmm_model": "./models/testModelR9_5mer_acgt_complement.model",
+  "template_hmm_model": "./models/testModelR9_5mer_acgt_template.model",
+  "job_count": 2,
+  "debug": false,
+  "two_d": false,
+  "output_dir": "./",
+  "constraint_trim": 3,
+  "diagonal_expansion": 5,
+  "traceBackDiagonals": 100,
+  "filter_reads": 0
+}

--- a/tests/runSignalAlign-config.json
+++ b/tests/runSignalAlign-config.json
@@ -24,8 +24,7 @@
       "number_of_kmer_assignments": 10,
       "alignment_file": "./tests/minion_test_reads/canonical_ecoli_R9/canonical_ecoli.bam",
       "recursive": false,
-      "assignments_dir": null,
-      "degenerate": "variant"
+      "assignments_dir": null
     }
   ],
   "path_to_bin": "./bin",


### PR DESCRIPTION
Update Docker test and remove deprecated keyword argument for the command-line test 

Closes #34 